### PR TITLE
Fix/Use deploy key for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
This pull request makes a small update to the workflow configuration for releases. The change switches the authentication method for checking out code from using a GitHub token to using an SSH deploy key.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L77-R77): Updated the `actions/checkout` step to use `ssh-key` with `${{ secrets.DEPLOY_KEY }}` instead of `token` with `${{ secrets.GITHUB_TOKEN }}` for authentication.