### PR TITLE
Feature/Specific serialization for exception causes

### DIFF
--- a/resokerr/core.py
+++ b/resokerr/core.py
@@ -191,7 +191,53 @@ class TypeUtils:
             False
         """
         return isinstance(obj, Serializable)
+    
+    @staticmethod
+    def is_exception(obj: Any) -> bool:
+        """Check if an object is an exception instance.
 
+        Args:
+            obj: The object to check.
+        Returns:
+            True if the object is an instance of BaseException, False otherwise.
+        
+        Example:
+            >>> TypeUtils.is_exception(ValueError("invalid"))
+            True
+            >>> TypeUtils.is_exception("not an exception")
+            False
+        """
+        return isinstance(obj, BaseException)
+
+    @staticmethod
+    def serialize_exception(exception: BaseException, as_dict: bool = False) -> Any:
+        """Serialize an exception to a JSON-compatible representation.
+
+        Args:
+            exc: The exception instance to serialize.
+            as_dict: If True, returns a dictionary with exception details.
+                     If False, returns the string representation of the exception.
+
+        Returns:
+            A JSON-serializable representation of the exception.
+        
+        Example:
+            >>> try:
+            ...     1 / 0
+            ... except ZeroDivisionError as e:
+            ...     TypeUtils.serialize_exception(e)
+            {'type': 'ZeroDivisionError', 'message': 'division by zero'}
+        """
+        if as_dict:
+            exception_dict = {
+                'name': type(exception).__name__,
+                'message': str(exception),
+            }
+            if exception.__cause__ is not None:
+                exception_dict['cause'] = TypeUtils.serialize_exception(exception.__cause__, as_dict=True)
+            return exception_dict
+        return str(exception)
+    
     @staticmethod
     def serialize(obj: Any) -> Any:
         """Serialize an object to a JSON-compatible representation.
@@ -222,6 +268,8 @@ class TypeUtils:
         if TypeUtils.has_to_dict(obj):
             serializable: Serializable = obj
             return serializable.to_dict()
+        if TypeUtils.is_exception(obj):
+            return TypeUtils.serialize_exception(obj, as_dict=True)
         return str(obj)
 
 


### PR DESCRIPTION
This pull request enhances the documentation and implementation of serialization and message severity handling in the `resokerr` library. The primary focus is on improving how exceptions and nested objects are serialized to JSON-compatible formats, clarifying message severity semantics, and updating the API documentation to reflect these changes. The README is updated extensively to describe new behaviors and usage patterns, and the codebase is updated to support recursive serialization of exceptions, metadata, and message details.

**Serialization improvements:**

* Added recursive serialization for exceptions, including support for chained exceptions via a new `TypeUtils.serialize_exception()` method. Exceptions are now represented as structured dicts with `name`, `message`, and `cause` fields. This applies to values, causes, metadata, and message details in both `Ok` and `Err` objects. [[1]](diffhunk://#diff-323ed7e61c82eac9f0c768196ef66e2b4518a54ea25706d5965a51fd498c346cR196-R247) [[2]](diffhunk://#diff-323ed7e61c82eac9f0c768196ef66e2b4518a54ea25706d5965a51fd498c346cL213-R285) [[3]](diffhunk://#diff-323ed7e61c82eac9f0c768196ef66e2b4518a54ea25706d5965a51fd498c346cL712-R776) [[4]](diffhunk://#diff-323ed7e61c82eac9f0c768196ef66e2b4518a54ea25706d5965a51fd498c346cL854-R919)
* Updated the serialization logic so that `dict` values are recursively serialized, lists/tuples are handled item-wise, and objects with `to_dict()` are properly serialized. Fallback is string conversion.
* Modified the `unwrap` methods in both `Ok` and `Err` to use the improved serialization logic when `as_dict=True`. [[1]](diffhunk://#diff-323ed7e61c82eac9f0c768196ef66e2b4518a54ea25706d5965a51fd498c346cR500) [[2]](diffhunk://#diff-323ed7e61c82eac9f0c768196ef66e2b4518a54ea25706d5965a51fd498c346cR552)

**Message severity handling:**

* Introduced a fourth severity level, `SUCCESS`, and clarified severity conversion rules: `ERROR` messages in `Ok` are downgraded to `WARNING`, and `SUCCESS` messages in `Err` are converted to `INFO`. The README now includes a table and code examples for these conversions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L379-R386) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L398-R441) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L949-R1086)
* Expanded the `MessageTrace` API to include a `success` factory method and updated the documentation to reflect the new severity level and conversion behavior.

**Documentation and API reference updates:**

* The README now documents generic type parameters (`V`, `E`, `M`), details the recursive serialization logic, and provides new usage examples for exception chaining and nested object serialization. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R959-R978) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L892-R1007) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L919-R1018) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L934-R1034) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L521-R572) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L720-R798) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L510-R540) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L698-R752)
* Attributes and methods in the API reference are updated to clarify immutability, accepted types, and the effects of the new serialization logic. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L892-R1007) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L919-R1018) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L934-R1034) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L949-R1086)

**Other changes:**

* Both `Ok` and `Err` classes are now marked as `@final` to prevent subclassing, as documented in the README.
* Minor test improvements, such as importing `json` in the test suite.